### PR TITLE
Fix typo in config_definition

### DIFF
--- a/slides/config_definition.html
+++ b/slides/config_definition.html
@@ -2960,7 +2960,7 @@ $config = array_merge(
           'first' <font color="#888a85">=&gt;</font> <small>boolean</small> <font color="#75507b">false</font>
           'second' <font color="#888a85">=&gt;</font> <small>boolean</small> <font color="#75507b">true</font>
     </code>
-    <p class="incremental"><em>Remarque:</em> array_replace fait la même chose pour un tablea associatif.</p>
+    <p class="incremental"><em>Remarque:</em> array_replace fait la même chose pour un tableau associatif.</p>
 </div>
 
 <div class="slide">


### PR DESCRIPTION
Fixes a little typo in the french slide.
